### PR TITLE
task/switch-working-directory-after-clone

### DIFF
--- a/src/theia/theia.ts
+++ b/src/theia/theia.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import * as path from "path";
 import simpleGit, { GitConfigScope } from "simple-git";
 import { hostname } from "os";
 import { cloneByGivenURL } from "../participation/cloning.service";
@@ -32,7 +33,7 @@ export async function initTheia() {
     vscode.commands.executeCommand("setContext", "scorpio.theia.givenExercise", true);
   }
 
-  // clone repository
+  // clone repository and set it as the workspace folder
   if (theiaEnv.GIT_URI) {
     const workspaceFolderUri = getWorkspaceFolder();
     if (!workspaceFolderUri) {
@@ -40,7 +41,12 @@ export async function initTheia() {
       return;
     }
 
-    cloneByGivenURL(theiaEnv.GIT_URI, workspaceFolderUri.fsPath);
+    // Skip if the workspace is already the cloned repo (window reloads after openFolder)
+    const repoName = path.basename(theiaEnv.GIT_URI.pathname, ".git");
+    if (path.basename(workspaceFolderUri.fsPath) !== repoName) {
+      const clonePath = await cloneByGivenURL(theiaEnv.GIT_URI, workspaceFolderUri.fsPath);
+      await vscode.commands.executeCommand("vscode.openFolder", vscode.Uri.file(clonePath));
+    }
   }
 
   // set git config values


### PR DESCRIPTION
### Description

In Theia environments where the extension is launched with a `GIT_URI`, the repository is now cloned into the workspace folder and the workspace is then switched to the cloned repo, so the user lands directly in the project files.

- `initTheia` awaits the clone, then calls `vscode.openFolder` to open the cloned repo as the workspace
- Guards against an infinite reactivation loop by skipping the clone if the workspace folder name already matches the repo name
- `cloneByGivenURL` now removes any existing clone directory before re-cloning, and re-throws clone errors so callers can react to failures

### Steps for Testing

1. Launch the Extension Development Host with `THEIA=true` and a `GIT_URI` env var pointing at a public git repo
2. Pass any empty workspace folder as the launch arg (e.g. `test-clone-destination`)
3. Verify the repo is cloned into that folder
4. Verify the window reloads with the cloned repo as the workspace root
5. Verify a second activation does **not** re-clone (workspace stays on the cloned repo)

#### Manual Tests

- [ ] Cloning succeeds and workspace switches to cloned repo
- [ ] No infinite re-clone loop on reactivation
- [ ] Stale clone directory is replaced cleanly on re-launch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository cloning logic to skip redundant clones when the current workspace already matches the repository being cloned
  * Enhanced workspace folder handling with more reliable asynchronous operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->